### PR TITLE
Fix typo in build status shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build 
 Status](https://semaphoreci.com/api/v1/twostoryrobot/react-search-lunr/branches/master/shields_badge.svg)](https://semaphoreci.com/twostoryrobot/react-search-lunr)
-[![npm version](http://img.shields.io/npm/v/REPO.svg?style=flat)](https://npmjs.org/package/REPO "View this project on npm")
 
 # react-search-lunr
 


### PR DESCRIPTION
Your Build Passed badge has a broken url. I have changed this to reflect the correct name of this repo.

Hope that's correct! 😄 