### PR TITLE
Failing id check is covered by test

### DIFF
--- a/react-search-lunr.test.js
+++ b/react-search-lunr.test.js
@@ -7,7 +7,7 @@ import ReactSearchLunr from './react-search-lunr'
 afterEach(cleanup)
 
 const documents = [
-  { id: 'a', name: 'test a', body: 'test a was found' },
+  { id: 1, name: 'test a', body: 'test a was found' },
   { id: 'b', name: 'test b', body: 'test b was unknown' },
   { id: 'c', name: 'ignore c', body: 'ignore this result' }
 ]


### PR DESCRIPTION
Integer id was compared by type to the string and failed to return a valid result. Added the test to cover this issue.