### PR TITLE
Use passed in ID key by props

### DIFF
--- a/react-search-lunr.js
+++ b/react-search-lunr.js
@@ -20,7 +20,7 @@ class ReactLunr extends React.Component {
       .search(filter) // search the index
       .map(({ ref, ...rest }) => ({
         ref,
-        item: this.state.documents.find(m => m.id == ref),
+        item: this.state.documents.find(m => m[this.props.id] == ref),
         ...rest
       })) // attach each item
     return results


### PR DESCRIPTION
The ID key of each entry may not be "id", so looking for
```     
        ...
        item: this.state.documents.find(m => m.id == ref),
        ...
```
will fail if the key is for example named "name" or something else.

Instead, using 

```     
        ...
        item: this.state.documents.find(m => m[this.props.id] == ref),
        ...
```

will work even if the id field is named anything other then id