### PR TITLE
Allow other fields to work as IDs and unit test

### DIFF
--- a/__snapshots__/react-search-lunr.test.js.snap
+++ b/__snapshots__/react-search-lunr.test.js.snap
@@ -10,3 +10,14 @@ exports[`should render only results matching initial filter 1`] = `
   </p>
 </div>
 `;
+
+exports[`should render results using a selected field as ID 1`] = `
+<div>
+  <h1>
+    test a
+  </h1>
+  <p>
+    test a was found
+  </p>
+</div>
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-lunr",
+  "name": "react-search-lunr",
   "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/react-search-lunr.js
+++ b/react-search-lunr.js
@@ -20,9 +20,10 @@ class ReactLunr extends React.Component {
       .search(filter) // search the index
       .map(({ ref, ...rest }) => ({
         ref,
-        item: this.state.documents.find(m => m.id == ref),
+        item: this.state.documents.find(m => m[this.props.id] == ref),
         ...rest
       })) // attach each item
+    console.log(filter, results)
     return results
   }
 

--- a/react-search-lunr.test.js
+++ b/react-search-lunr.test.js
@@ -81,3 +81,21 @@ test('updating filter will rerender with new results', async () => {
   expect(queryByText('test a')).not.toBeInTheDocument()
   expect(queryByText('ignore c')).toBeInTheDocument()
 })
+
+test('should render results using a selected field as ID', async () => {
+  const { container, queryByText } = render(
+    <ReactSearchLunr
+      id="name"
+      documents={documents}
+      fields={['body']}
+      filter="test">
+      {mapResults}
+    </ReactSearchLunr>
+  )
+
+  expect(queryByText('test a')).toBeInTheDocument()
+  expect(queryByText('test b')).toBeInTheDocument()
+  expect(queryByText('ignore c')).not.toBeInTheDocument()
+
+  expect(container.firstChild).toMatchSnapshot()
+})


### PR DESCRIPTION
This PR is a re-opening of #39. 

The ID key of each entry may not be `id`, so looking for
```     
        ...
        item: this.state.documents.find(m => m.id == ref),
        ...
```
will fail if the key is for example named `name` or something else.

Instead, using 

```     
        ...
        item: this.state.documents.find(m => m[this.props.id] == ref),
        ...
```

will work even if the id field is named anything other then `id`

A unit test was also added, testing if the results are correct when using as id the `name` field:
```
test('should render results using a selected field as ID', async () => {
  const { container, queryByText } = render(
    <ReactSearchLunr
      id="name"
      documents={documents}
      fields={['body']}
      filter="test">
      {mapResults}
    </ReactSearchLunr>
  )

  expect(queryByText('test a')).toBeInTheDocument()
  expect(queryByText('test b')).toBeInTheDocument()
  expect(queryByText('ignore c')).not.toBeInTheDocument()

  expect(container.firstChild).toMatchSnapshot()
})
```